### PR TITLE
Add bundler gem caching to GH actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Bundle install
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: Install postgres
         run: |
           sudo apt-get -yqq install libpq-dev


### PR DESCRIPTION
[bundler caching improves speed to CI tests](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically)
